### PR TITLE
Remove unused pad utils

### DIFF
--- a/str/format.go
+++ b/str/format.go
@@ -19,7 +19,7 @@ func FormatFloatWithCommas(f float64) string {
 
 	reversed := ReverseString(parts[0])
 	reversedWithCommas := ""
-	
+
 	for i, c := range reversed {
 		if i > 0 && i%3 == 0 {
 			reversedWithCommas += ","
@@ -57,24 +57,6 @@ func TruncateString(s string, maxLen int) string {
 		return s[:maxLen]
 	}
 	return s[:maxLen-3] + "..."
-}
-
-// PadLeft pads a string on the left to reach a desired length
-func PadLeft(s string, padChar rune, length int) string {
-	if len(s) >= length {
-		return s
-	}
-	padding := strings.Repeat(string(padChar), length-len(s))
-	return padding + s
-}
-
-// PadRight pads a string on the right to reach a desired length
-func PadRight(s string, padChar rune, length int) string {
-	if len(s) >= length {
-		return s
-	}
-	padding := strings.Repeat(string(padChar), length-len(s))
-	return s + padding
 }
 
 // IsEmpty checks if a string is empty or contains only whitespace

--- a/str/format_test.go
+++ b/str/format_test.go
@@ -97,56 +97,6 @@ func TestTruncateString(t *testing.T) {
 	}
 }
 
-func TestPadLeft(t *testing.T) {
-	tests := []struct {
-		name     string
-		s        string
-		padChar  rune
-		length   int
-		expected string
-	}{
-		{"empty string", "", ' ', 5, "     "},
-		{"already at length", "hello", ' ', 5, "hello"},
-		{"longer than length", "hello", ' ', 3, "hello"},
-		{"needs padding", "hello", ' ', 10, "     hello"},
-		{"different pad char", "123", '0', 5, "00123"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := PadLeft(tc.s, tc.padChar, tc.length)
-			if result != tc.expected {
-				t.Errorf("PadLeft(%s, %c, %d) = %s; expected %s", tc.s, tc.padChar, tc.length, result, tc.expected)
-			}
-		})
-	}
-}
-
-func TestPadRight(t *testing.T) {
-	tests := []struct {
-		name     string
-		s        string
-		padChar  rune
-		length   int
-		expected string
-	}{
-		{"empty string", "", ' ', 5, "     "},
-		{"already at length", "hello", ' ', 5, "hello"},
-		{"longer than length", "hello", ' ', 3, "hello"},
-		{"needs padding", "hello", ' ', 10, "hello     "},
-		{"different pad char", "123", '0', 5, "12300"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := PadRight(tc.s, tc.padChar, tc.length)
-			if result != tc.expected {
-				t.Errorf("PadRight(%s, %c, %d) = %s; expected %s", tc.s, tc.padChar, tc.length, result, tc.expected)
-			}
-		})
-	}
-}
-
 func TestIsEmpty(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
This pull request simplifies the `str` package by removing unused padding functions and their associated tests. The most important changes include the removal of `PadLeft` and `PadRight` functions and their corresponding test cases.

### Codebase simplification:

* Removed the `PadLeft` and `PadRight` functions from `str/format.go` as they were no longer in use.
* Deleted the corresponding test cases for `PadLeft` and `PadRight` from `str/format_test.go` to clean up unused code.