### PR TITLE
feat(logger): add support for structured context as loosely typed key-…

### DIFF
--- a/logger/doc.go
+++ b/logger/doc.go
@@ -64,6 +64,34 @@ logger with string formatting (using the sugared logger):
 	// Info level with formatting
 	logger.Infof("Application started with version %s in %s environment", version, env)
 
+# Structured Logging
+
+Log with structured key-value pairs (using the sugared logger):
+
+	// Debug level with structured key-value pairs
+	logger.Debugw("Processing item", 
+		"item_id", item.ID, 
+		"status", item.Status,
+	)
+
+	// Info level with structured key-value pairs
+	logger.Infow("Application started", 
+		"version", version, 
+		"environment", env,
+	)
+
+	// Warning level with structured key-value pairs
+	logger.Warnw("API rate limit approaching", 
+		"current", current, 
+		"limit", limit,
+	)
+
+	// Error level with structured key-value pairs
+	logger.Errorw("Failed to process payment", 
+		"user_id", userID, 
+		"error", err.Error(),
+	)
+
 # Context-Aware Logging
 
 Use context to pass loggers:

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -183,9 +183,19 @@ func Debugf(template string, args ...interface{}) {
 	GetSugared().Debugf(template, args...)
 }
 
+// Debugw logs at debug level with structured key-value pairs (sugared logger)
+func Debugw(msg string, keysAndValues ...interface{}) {
+	GetSugared().Debugw(msg, keysAndValues...)
+}
+
 // Infof logs at info level with formatting (sugared logger)
 func Infof(template string, args ...interface{}) {
 	GetSugared().Infof(template, args...)
+}
+
+// Infow logs at info level with structured key-value pairs (sugared logger)
+func Infow(msg string, keysAndValues ...interface{}) {
+	GetSugared().Infow(msg, keysAndValues...)
 }
 
 // Warnf logs at warn level with formatting (sugared logger)
@@ -193,14 +203,29 @@ func Warnf(template string, args ...interface{}) {
 	GetSugared().Warnf(template, args...)
 }
 
+// Warnw logs at warn level with structured key-value pairs (sugared logger)
+func Warnw(msg string, keysAndValues ...interface{}) {
+	GetSugared().Warnw(msg, keysAndValues...)
+}
+
 // Errorf logs at error level with formatting (sugared logger)
 func Errorf(template string, args ...interface{}) {
 	GetSugared().Errorf(template, args...)
 }
 
+// Errorw logs at error level with structured key-value pairs (sugared logger)
+func Errorw(msg string, keysAndValues ...interface{}) {
+	GetSugared().Errorw(msg, keysAndValues...)
+}
+
 // Fatalf logs at fatal level with formatting and then calls os.Exit(1)
 func Fatalf(template string, args ...interface{}) {
 	GetSugared().Fatalf(template, args...)
+}
+
+// Fatalw logs at fatal level with structured key-value pairs (sugared logger) and then calls os.Exit(1)
+func Fatalw(msg string, keysAndValues ...interface{}) {
+	GetSugared().Fatalw(msg, keysAndValues...)
 }
 
 // Sync flushes any buffered log entries


### PR DESCRIPTION
This pull request introduces structured logging capabilities to the `logger` package by adding new methods for logging with key-value pairs, updating documentation, and implementing corresponding tests. These changes enhance the flexibility and clarity of log messages by supporting structured data.

### Structured Logging Enhancements:

* **Documentation Update**: Added examples of structured logging using key-value pairs to `logger/doc.go`, demonstrating how to use the new `*w` methods (`Debugw`, `Infow`, `Warnw`, `Errorw`) for various log levels.

* **New Structured Logging Methods**: Added `*w` methods (`Debugw`, `Infow`, `Warnw`, `Errorw`, `Fatalw`) to `logger/logger.go` for logging with key-value pairs using the sugared logger. These methods provide a more structured and readable format for log entries.

### Testing Enhancements:

* **Unit Tests for Structured Logging**: Added tests for the new `*w` methods in `logger/logger_test.go` to ensure correct behavior, including validation of log messages and key-value pairs in the log context. The `Fatalw` method was excluded from testing due to its use of `os.Exit(1)`