### PR TITLE
feat(router): add optional healthcheck and remove custom recoverer

### DIFF
--- a/router/doc.go
+++ b/router/doc.go
@@ -10,7 +10,8 @@ a consistent approach to building HTTP services with sensible defaults.
   - Integration with the go-core/api package for error handling
   - Structured logging with the go-core/logger package
   - Request tracing with unique request IDs
-  - Panic recovery with proper error responses
+  - Standard panic recovery via Chi's Recoverer middleware
+  - Optional healthcheck endpoint at /healthz
   - Timeout handling
   - Configurable middleware options
 
@@ -18,11 +19,10 @@ a consistent approach to building HTTP services with sensible defaults.
 
 Creating a new router with default middleware:
 
-	// Create a new router with default middleware
+	// Create a new router with default middleware (includes /healthz endpoint)
 	r := router.New()
 
-	// Add routes
-	r.Get("/api/health", healthCheckHandler)
+	// Add custom routes
 	r.Post("/api/users", createUserHandler)
 
 	// Start the server
@@ -70,15 +70,16 @@ You can create route groups with shared middleware:
 You can customize the router's middleware:
 
 	r := router.NewWithOptions(router.Options{
-	    EnableLogging:   true,
-	    EnableRecovery:  true,
-	    EnableRequestID: true,
-	    EnableTimeout:   true,
-	    TimeoutDuration: 30 * time.Second,
+	    EnableLogging:     true,
+	    EnableRecovery:    true,
+	    EnableRequestID:   true,
+	    EnableTimeout:     true,
+	    EnableHealthcheck: true,  // Adds a /healthz endpoint
+	    TimeoutDuration:   30 * time.Second,
 	    LoggerOptions: router.LoggerOptions{
 	        LogRequestHeaders:  true,
 	        LogResponseHeaders: false,
-	        SkipPaths:          []string{"/health", "/metrics"},
+	        SkipPaths:          []string{"/healthz", "/metrics"},
 	    },
 	})
 

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -1,12 +1,9 @@
 package router
 
 import (
-	"fmt"
 	"net/http"
-	"runtime/debug"
 	"time"
 
-	"github.com/StairSupplies/go-core/api"
 	"github.com/StairSupplies/go-core/logger"
 	"github.com/go-chi/chi/v5/middleware"
 	"go.uber.org/zap"
@@ -28,10 +25,10 @@ func Logger(opts LoggerOptions) func(next http.Handler) http.Handler {
 
 			// Start timer
 			start := time.Now()
-			
+
 			// Create a response writer wrapper to capture status code
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
-			
+
 			// Prepare request logger with common fields
 			requestLog := logger.With(
 				zap.String("method", r.Method),
@@ -39,7 +36,7 @@ func Logger(opts LoggerOptions) func(next http.Handler) http.Handler {
 				zap.String("request_id", middleware.GetReqID(r.Context())),
 				zap.String("remote_addr", r.RemoteAddr),
 			)
-			
+
 			// Log request headers if enabled
 			if opts.LogRequestHeaders {
 				for k, v := range r.Header {
@@ -48,17 +45,17 @@ func Logger(opts LoggerOptions) func(next http.Handler) http.Handler {
 					}
 				}
 			}
-			
+
 			// Add logger to request context
 			ctx := logger.ContextWithLogger(r.Context(), requestLog)
 			r = r.WithContext(ctx)
-			
+
 			// Log request start
 			requestLog.Info("HTTP request started")
-			
+
 			// Process request
 			next.ServeHTTP(ww, r)
-			
+
 			// Log response
 			duration := time.Since(start)
 			responseLog := requestLog.With(
@@ -66,7 +63,7 @@ func Logger(opts LoggerOptions) func(next http.Handler) http.Handler {
 				zap.Duration("duration", duration),
 				zap.Int("size", ww.BytesWritten()),
 			)
-			
+
 			// Log response headers if enabled
 			if opts.LogResponseHeaders {
 				for k, v := range ww.Header() {
@@ -75,39 +72,8 @@ func Logger(opts LoggerOptions) func(next http.Handler) http.Handler {
 					}
 				}
 			}
-			
-			responseLog.Info("HTTP request completed")
-		})
-	}
-}
 
-// Recoverer recovers from panics and logs them.
-// It ensures that the application doesn't crash when a panic occurs in a handler,
-// and instead returns a 500 Internal Server Error response.
-func Recoverer() func(next http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			defer func() {
-				if rvr := recover(); rvr != nil {
-					stack := debug.Stack()
-					
-					// Log the panic
-					reqID := middleware.GetReqID(r.Context())
-					ctx := r.Context()
-					
-					logger.WithContext(ctx).Error("panic recovered",
-						zap.Any("panic", rvr),
-						zap.String("request_id", reqID),
-						zap.String("stack", string(stack)),
-					)
-					
-					// Return a 500 error
-					err := fmt.Errorf("internal server error")
-					api.WriteError(w, api.ServerError(err))
-				}
-			}()
-			
-			next.ServeHTTP(w, r)
+			responseLog.Info("HTTP request completed")
 		})
 	}
 }

--- a/router/middleware_test.go
+++ b/router/middleware_test.go
@@ -13,57 +13,36 @@ func TestLogger(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("test"))
 	})
-	
+
 	// Create the logger middleware
 	loggerMiddleware := Logger(LoggerOptions{
 		LogRequestHeaders:  true,
 		LogResponseHeaders: true,
 		SkipPaths:          []string{"/skip"},
 	})
-	
+
 	// Wrap the test handler with logger middleware
 	handler := loggerMiddleware(testHandler)
-	
+
 	// Test normal request
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("X-Test", "test")
 	w := httptest.NewRecorder()
-	
+
 	handler.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
 	}
-	
+
 	// Test skipped path
 	req = httptest.NewRequest("GET", "/skip", nil)
 	w = httptest.NewRecorder()
-	
+
 	handler.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
-	}
-}
-
-func TestRecoverer(t *testing.T) {
-	// Create a test handler that panics
-	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		panic("test panic")
-	})
-	
-	// Wrap the test handler with recoverer middleware
-	handler := Recoverer()(panicHandler)
-	
-	// Test request that causes panic
-	req := httptest.NewRequest("GET", "/panic", nil)
-	w := httptest.NewRecorder()
-	
-	handler.ServeHTTP(w, req)
-	
-	// Should recover and return 500
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, w.Code)
 	}
 }
 
@@ -74,29 +53,29 @@ func TestTimeout(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("done"))
 	})
-	
+
 	// Test successful response (no timeout)
 	timeoutMiddleware := Timeout(100 * time.Millisecond)
 	handler := timeoutMiddleware(slowHandler)
-	
+
 	req := httptest.NewRequest("GET", "/test", nil)
 	w := httptest.NewRecorder()
-	
+
 	handler.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
 	}
-	
+
 	// Test timeout
 	timeoutMiddleware = Timeout(10 * time.Millisecond)
 	handler = timeoutMiddleware(slowHandler)
-	
+
 	req = httptest.NewRequest("GET", "/test", nil)
 	w = httptest.NewRecorder()
-	
+
 	handler.ServeHTTP(w, req)
-	
+
 	// Chi's timeout middleware doesn't automatically write an error response,
 	// but the connection should be closed. We can't easily test this in a unit test.
 }
@@ -107,16 +86,16 @@ func TestRequestID(t *testing.T) {
 		// Just return OK, we're not testing the request ID value itself
 		w.WriteHeader(http.StatusOK)
 	})
-	
+
 	// Wrap the test handler with request ID middleware
 	handler := RequestID(testHandler)
-	
+
 	// Test request
 	req := httptest.NewRequest("GET", "/test", nil)
 	w := httptest.NewRecorder()
-	
+
 	handler.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -51,11 +51,11 @@ type LoggerOptions struct {
 // These defaults provide a balance of functionality and performance.
 func DefaultOptions() Options {
 	return Options{
-		EnableLogging:    true,
-		EnableRecovery:   true,
-		EnableRequestID:  true,
-		EnableTimeout:    true,
-		TimeoutDuration:  60 * time.Second,
+		EnableLogging:   true,
+		EnableRecovery:  true,
+		EnableRequestID: true,
+		EnableTimeout:   true,
+		TimeoutDuration: 60 * time.Second,
 		LoggerOptions: LoggerOptions{
 			LogRequestHeaders:  false,
 			LogResponseHeaders: false,
@@ -75,26 +75,26 @@ func New() *Router {
 // Use this when you need to customize the router's behavior.
 func NewWithOptions(options Options) *Router {
 	r := chi.NewRouter()
-	
+
 	// Apply middleware based on options
 	if options.EnableRequestID {
 		r.Use(middleware.RequestID)
 	}
-	
+
 	if options.EnableRecovery {
-		r.Use(Recoverer())
+		r.Use(middleware.Recoverer)
 	}
-	
+
 	if options.EnableLogging {
 		r.Use(Logger(options.LoggerOptions))
 	}
-	
+
 	if options.EnableTimeout {
 		r.Use(middleware.Timeout(options.TimeoutDuration))
 	}
-	
+
 	return &Router{
-		Router: r,
+		Router:  r,
 		options: options,
 	}
 }
@@ -112,24 +112,24 @@ func (r *Router) Group(fn func(r chi.Router)) chi.Router {
 		Router:  chi.NewRouter(),
 		options: r.options,
 	}
-	
+
 	// Apply middleware to subRouter if needed
 	if r.options.EnableRequestID {
 		subRouter.Use(middleware.RequestID)
 	}
-	
+
 	if r.options.EnableRecovery {
-		subRouter.Use(Recoverer())
+		subRouter.Use(middleware.Recoverer)
 	}
-	
+
 	if r.options.EnableLogging {
 		subRouter.Use(Logger(r.options.LoggerOptions))
 	}
-	
+
 	if r.options.EnableTimeout {
 		subRouter.Use(middleware.Timeout(r.options.TimeoutDuration))
 	}
-	
+
 	fn(subRouter)
 	return subRouter
 }
@@ -147,11 +147,11 @@ func (r *Router) WithMiddleware(middlewares ...func(http.Handler) http.Handler) 
 		Router:  r.Router,
 		options: r.options,
 	}
-	
+
 	for _, m := range middlewares {
 		newRouter.Use(m)
 	}
-	
+
 	return newRouter
 }
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -120,8 +120,6 @@ func TestRouterGroup(t *testing.T) {
 }
 
 func TestWithMiddleware(t *testing.T) {
-	r := New()
-	
 	// Create a custom middleware
 	testMiddleware := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -130,10 +128,10 @@ func TestWithMiddleware(t *testing.T) {
 		})
 	}
 	
-	// Add the middleware
-	r = r.WithMiddleware(testMiddleware)
+	// Create router with middleware first
+	r := New().WithMiddleware(testMiddleware)
 	
-	// Add a test handler
+	// Then add a test handler
 	r.Get("/test", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("test"))


### PR DESCRIPTION
This pull request introduces two major changes to the `router` package: replacing the custom `Recoverer` middleware with Chi's built-in `Recoverer` and adding an optional `/healthz` endpoint for health checks. These updates simplify the codebase and enhance functionality by leveraging existing middleware and providing a standardized health check route.

### Middleware Changes:
* Replaced the custom `Recoverer` middleware with Chi's built-in `Recoverer` middleware across all router configurations, including `NewWithOptions`, `Group`, and `WithMiddleware` methods. This change removes the custom panic recovery implementation and associated test cases. [[1]](diffhunk://#diff-ce0daf07ecc0db34b3fbf9ec878765c1c8caf6fab579d4ec26e273bac1324951L84-L114) [[2]](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964L85-R88) [[3]](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964L122-R132) [[4]](diffhunk://#diff-f7657f10ffcfd289ed8e53afafb60d19946bfffb445e168d16ab2a6b31f54274L49-L69)

### Health Check Endpoint:
* Added an optional `/healthz` endpoint for health checks, enabled via the `EnableHealthcheck` option. This endpoint is included in the default options and can be configured in `NewWithOptions`, `Group`, and `WithMiddleware` methods. [[1]](diffhunk://#diff-9423f7fc5bd7c8b3fdeda848f2b6e758fd9198b4c936eecd7c81021ff6c6e530L13-R25) [[2]](diffhunk://#diff-9423f7fc5bd7c8b3fdeda848f2b6e758fd9198b4c936eecd7c81021ff6c6e530R77-R82) [[3]](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964R31-R32) [[4]](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964R60-R66) [[5]](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964R99-R105) [[6]](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964R143-R149) [[7]](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964L143-R203)

### Code Simplification:
* Removed unused imports (`fmt`, `runtime/debug`, and `github.com/StairSupplies/go-core/api`) from `router/middleware.go` after eliminating the custom `Recoverer` middleware.

### Test Updates:
* Updated test cases to reflect the removal of the custom `Recoverer` middleware and adjusted the `TestWithMiddleware` test to ensure middleware is applied before adding routes. [[1]](diffhunk://#diff-f7657f10ffcfd289ed8e53afafb60d19946bfffb445e168d16ab2a6b31f54274L49-L69) [[2]](diffhunk://#diff-04def44a4cd6a9c8549a994b1738c32da5163b39623f56abea1b20ae1ea14428L123-L124) [[3]](diffhunk://#diff-04def44a4cd6a9c8549a994b1738c32da5163b39623f56abea1b20ae1ea14428L133-R134)