### PR TITLE
refactor(rest): rename ErrNotFound to ErrResourceNotFound

### DIFF
--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -200,8 +200,8 @@ func TestClientRequest(t *testing.T) {
 		}
 
 		// Check error details
-		if clientErr.Err != ErrNotFound {
-			t.Errorf("Expected ErrNotFound, got %v", clientErr.Err)
+		if clientErr.Err != ErrResourceNotFound {
+			t.Errorf("Expected ErrResourceNotFound, got %v", clientErr.Err)
 		}
 
 		if clientErr.Message != "Resource not found" {

--- a/rest/doc.go
+++ b/rest/doc.go
@@ -62,7 +62,7 @@ The package provides standardized error handling:
 	err := client.Get(ctx, "/users/123", &user)
 	if err != nil {
 		switch {
-		case errors.Is(err, rest.ErrNotFound):
+		case errors.Is(err, rest.ErrResourceNotFound):
 			fmt.Println("User not found")
 		case errors.Is(err, rest.ErrUnauthorized):
 			fmt.Println("Authentication required")

--- a/rest/errors.go
+++ b/rest/errors.go
@@ -14,8 +14,8 @@ var (
 	// ErrUnauthorized indicates that the request was rejected due to authentication failure.
 	ErrUnauthorized = errors.New("unauthorized")
 
-	// ErrNotFound indicates that the requested resource could not be found.
-	ErrNotFound = errors.New("resource not found")
+	// ErrResourceNotFound indicates that the requested resource could not be found.
+	ErrResourceNotFound = errors.New("resource not found")
 
 	// ErrServerError indicates that the server encountered an error processing the request.
 	ErrServerError = errors.New("server error")
@@ -28,6 +28,9 @@ var (
 
 	// ErrUnprocessableEntity indicates that the server understood the request but was unable to process it.
 	ErrUnprocessableEntity = errors.New("unprocessable entity")
+
+	// ErrInvalidResponse indicates that the response from the server was invalid or malformed.
+	ErrInvalidResponse = errors.New("invalid response")
 )
 
 // ClientError represents an error from the client.
@@ -65,7 +68,7 @@ func getErrorByStatusCode(statusCode int) error {
 	case statusCode == http.StatusUnauthorized:
 		return ErrUnauthorized
 	case statusCode == http.StatusNotFound:
-		return ErrNotFound
+		return ErrResourceNotFound
 	case statusCode == http.StatusUnprocessableEntity:
 		return ErrUnprocessableEntity
 	case statusCode >= 400 && statusCode < 500:

--- a/rest/errors_test.go
+++ b/rest/errors_test.go
@@ -11,7 +11,7 @@ func TestClientError_Error(t *testing.T) {
 	// Test with message
 	t.Run("with message", func(t *testing.T) {
 		err := &ClientError{
-			Err:     ErrNotFound,
+			Err:     ErrResourceNotFound,
 			Message: "resource not found",
 		}
 
@@ -39,7 +39,7 @@ func TestClientError_Error(t *testing.T) {
 }
 
 func TestClientError_Unwrap(t *testing.T) {
-	underlying := ErrNotFound
+	underlying := ErrResourceNotFound
 	err := &ClientError{
 		Err:     underlying,
 		Message: "test message",
@@ -52,7 +52,7 @@ func TestClientError_Unwrap(t *testing.T) {
 	}
 
 	// Test with errors.Is
-	if !errors.Is(err, ErrNotFound) {
+	if !errors.Is(err, ErrResourceNotFound) {
 		t.Errorf("errors.Is() failed to find the underlying error")
 	}
 }
@@ -79,7 +79,7 @@ func TestGetErrorByStatusCode(t *testing.T) {
 		expected   error
 	}{
 		{http.StatusUnauthorized, ErrUnauthorized},
-		{http.StatusNotFound, ErrNotFound},
+		{http.StatusNotFound, ErrResourceNotFound},
 		{http.StatusUnprocessableEntity, ErrUnprocessableEntity},
 		{http.StatusBadRequest, ErrInvalidRequest},
 		{http.StatusConflict, ErrInvalidRequest},
@@ -115,7 +115,7 @@ func TestSentinelErrors(t *testing.T) {
 	}{
 		{ErrInvalidRequest, "invalid request"},
 		{ErrUnauthorized, "unauthorized"},
-		{ErrNotFound, "resource not found"},
+		{ErrResourceNotFound, "resource not found"},
 		{ErrServerError, "server error"},
 		{ErrConnectionFailed, "connection failed"},
 		{ErrTimeout, "request timed out"},

--- a/rest/example_test.go
+++ b/rest/example_test.go
@@ -277,7 +277,7 @@ func ExampleWithServiceName() {
 func ExampleNewClientError() {
 	// Create a custom client error
 	err := rest.NewClientError(
-		rest.ErrNotFound,
+		rest.ErrResourceNotFound,
 		"User with ID 123 not found",
 		"USER_NOT_FOUND",
 	)


### PR DESCRIPTION
Renamed ErrNotFound to ErrResourceNotFound for improved clarity and added ErrInvalidResponse for handling malformed server responses.

This change makes the error name more explicit about what wasn't found (a resource).